### PR TITLE
Feature: add createdAt timestamp to levels data model, used to order …

### DIFF
--- a/app/levels/(models)/level.interface.tsx
+++ b/app/levels/(models)/level.interface.tsx
@@ -4,4 +4,5 @@ export default interface ILevel {
   author?: string;
   new?: boolean;
   words: string[];
+  createdAt: number;
 }

--- a/app/levels/page.tsx
+++ b/app/levels/page.tsx
@@ -85,7 +85,7 @@ export default function LevelsPage(props: LevelsPageProps) {
               customClass={getDifficultyColor(level.difficulty)}
             >
               <NewBadge>
-                {level.author !== undefined ? (
+                {level.author ? (
                   <AuthorBadge label={level.author}>
                     <LevelButton
                       level={level}
@@ -106,7 +106,13 @@ export default function LevelsPage(props: LevelsPageProps) {
               label={getDifficulty(level.difficulty)}
               customClass={getDifficultyColor(level.difficulty)}
             >
-              <LevelButton level={level} />
+              {level.author ? (
+                <AuthorBadge label={level.author}>
+                  <LevelButton level={level} />
+                </AuthorBadge>
+              ) : (
+                <LevelButton level={level} />
+              )}
             </Badge>
           )
         )}

--- a/lib/services/levelService.tsx
+++ b/lib/services/levelService.tsx
@@ -3,7 +3,9 @@ import ILevel from '../../app/levels/(models)/level.interface';
 export async function getLevels(): Promise<ILevel[]> {
   const response = await fetch('/api/level');
   const json = await response.json();
-  let levels = json.levels as ILevel[];
-  levels = levels.sort((a) => (a.new ?? false ? -1 : 1));
+  const levels = json.levels as ILevel[];
+
+  levels.sort((a) => (a.new ?? false ? -1 : 1));
+  levels.sort((a, b) => b.createdAt - a.createdAt);
   return levels;
 }

--- a/pages/api/level.tsx
+++ b/pages/api/level.tsx
@@ -16,6 +16,7 @@ export default async function handler(
           author: level.author as string,
           new: level.new as boolean,
           words: (level.words as string).split(','),
+          createdAt: Date.parse(level.created_at),
         };
       });
       res.json({ levels: convertedLevels });


### PR DESCRIPTION
- Add `createdAt` timestamp to levels data model, so that we can order the levels from newest to oldest